### PR TITLE
[BUGFIX] Fix "All valid files" bug

### DIFF
--- a/FileBrowser/ImGuiFileBrowser.cpp
+++ b/FileBrowser/ImGuiFileBrowser.cpp
@@ -99,6 +99,7 @@ namespace imgui_addons
         is_dir = false;
         filter_dirty = true;
         is_appearing = true;
+        show_all_valid_files = false;
 
         //Clear pointer references to subdirs and subfiles
         filtered_dirs.clear();


### PR DESCRIPTION
Fix issue #54:
After the file dialog is used once and a file is selected with the option "All valid files," the next file dialog opened will have the first extension selected, but will allow all files to be selected. The problem persists on future file dialogs until another extension is selected on the drop down.

The fix was just adding the line "show_all_valid_files = false;" to closeDialog()